### PR TITLE
Save window size, position and state

### DIFF
--- a/data/xyz.gelez.spreadsheet.gschema.xml
+++ b/data/xyz.gelez.spreadsheet.gschema.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<schemalist>
+  <schema path="/xyz/gelez/spreadsheet/" id="xyz.gelez.spreadsheet">
+    <key name="window-width" type="i">
+      <default>800</default>
+      <summary>Window width</summary>
+      <description>Width of last closed window</description>
+    </key>
+    <key name="window-height" type="i">
+      <default>700</default>
+      <summary>Window height</summary>
+      <description>Height of last closed window</description>
+    </key>
+    <key name="window-x" type="i">
+      <default>-1</default>
+      <summary>Window x position</summary>
+      <description>X position of last closed window</description>
+    </key>
+    <key name="window-y" type="i">
+      <default>-1</default>
+      <summary>Window y position</summary>
+      <description>Y position of last closed window</description>
+    </key>
+    <key name="window-maximized" type="b">
+      <default>false</default>
+      <summary>Open window maximized</summary>
+      <description>If true, window opens maximized</description>
+    </key>
+  </schema>
+</schemalist>

--- a/meson.build
+++ b/meson.build
@@ -56,3 +56,10 @@ executable(meson.project_name(),
   install: true,
   link_args: ['-lm']
 )
+
+install_data(
+  'data/xyz.gelez.spreadsheet.gschema.xml',
+  install_dir: join_paths(get_option('datadir'), 'glib-2.0', 'schemas')
+)
+
+meson.add_install_script('meson/post_install.py')

--- a/meson/post_install.py
+++ b/meson/post_install.py
@@ -1,0 +1,10 @@
+#!/usr/bin/env python3
+
+from os import environ, path
+from subprocess import call
+
+schemadir = path.join(environ['MESON_INSTALL_PREFIX'], 'share', 'glib-2.0', 'schemas')
+
+if not environ.get('DESTDIR'):
+        print('Completing gsettings schemas…')
+        call(['glib-compile-schemas', schemadir])

--- a/meson/post_install.py
+++ b/meson/post_install.py
@@ -6,5 +6,5 @@ from subprocess import call
 schemadir = path.join(environ['MESON_INSTALL_PREFIX'], 'share', 'glib-2.0', 'schemas')
 
 if not environ.get('DESTDIR'):
-        print('Completing gsettings schemas…')
-        call(['glib-compile-schemas', schemadir])
+    print('Completing gsettings schemas…')
+    call(['glib-compile-schemas', schemadir])

--- a/src/App.vala
+++ b/src/App.vala
@@ -50,7 +50,7 @@ public class Spreadsheet.App : Gtk.Application {
         var window_height = settings.get_int ("window-height");
         var window_maximized = settings.get_boolean ("window-maximized");
 
-        if (window_x != -1 || window_y != -1) {
+        if (window_x != -1 || window_y != -1) { // Not a first time running
             window = new MainWindow.with_state (this, window_x, window_y, window_width, window_height, window_maximized);
         } else {
             window = new MainWindow (this, window_width, window_height); // First time running

--- a/src/App.vala
+++ b/src/App.vala
@@ -43,6 +43,7 @@ public class Spreadsheet.App : Gtk.Application {
     }
 
     public override void activate () {
+        // Fetch window state from GLib.Settings
         var window_x = settings.get_int ("window-x");
         var window_y = settings.get_int ("window-y");
         var window_width = settings.get_int ("window-width");
@@ -52,7 +53,7 @@ public class Spreadsheet.App : Gtk.Application {
         if (window_x != -1 || window_y != -1) {
             window = new MainWindow.with_state (this, window_x, window_y, window_width, window_height, window_maximized);
         } else {
-            window = new MainWindow (this, window_width, window_height);
+            window = new MainWindow (this, window_width, window_height); // First time running
         }
     }
 }

--- a/src/App.vala
+++ b/src/App.vala
@@ -47,7 +47,7 @@ public class Spreadsheet.App : Gtk.Application {
         var window_y = settings.get_int ("window-y");
         var window_width = settings.get_int ("window-width");
         var window_height = settings.get_int ("window-height");
-        var window_maximized = settings.get_int ("window-maximized");
+        var window_maximized = settings.get_boolean ("window-maximized");
 
         if (window_x != -1 || window_y != -1) {
             window = new MainWindow.with_state (this, window_x, window_y, window_width, window_height);

--- a/src/App.vala
+++ b/src/App.vala
@@ -3,12 +3,18 @@ using Spreadsheet.UI;
 using Spreadsheet.Models;
 
 public class Spreadsheet.App : Gtk.Application {
+    public static GLib.Settings settings;
+    public MainWindow window;
 
     public static ArrayList<Function> functions { get; set; default = new ArrayList<Function> (); }
 
     public static int main (string[] args) {
         Gtk.init (ref args);
         return new App ().run (args);
+    }
+
+    static construct {
+        settings = new Settings ("xyz.gelez.spreadsheet");
     }
 
     construct {
@@ -37,6 +43,16 @@ public class Spreadsheet.App : Gtk.Application {
     }
 
     public override void activate () {
-        new MainWindow (this).present ();
+        var window_x = settings.get_int ("window-x");
+        var window_y = settings.get_int ("window-y");
+        var window_width = settings.get_int ("window-width");
+        var window_height = settings.get_int ("window-height");
+        var window_maximized = settings.get_int ("window-maximized");
+
+        if (window_x != -1 || window_y != -1) {
+            window = new MainWindow.with_state (this, window_x, window_y, window_width, window_height);
+        } else {
+            window = new MainWindow (this, window_width, window_height);
+        }
     }
 }

--- a/src/App.vala
+++ b/src/App.vala
@@ -50,7 +50,7 @@ public class Spreadsheet.App : Gtk.Application {
         var window_maximized = settings.get_boolean ("window-maximized");
 
         if (window_x != -1 || window_y != -1) {
-            window = new MainWindow.with_state (this, window_x, window_y, window_width, window_height);
+            window = new MainWindow.with_state (this, window_x, window_y, window_width, window_height, window_maximized);
         } else {
             window = new MainWindow (this, window_width, window_height);
         }

--- a/src/UI/MainWindow.vala
+++ b/src/UI/MainWindow.vala
@@ -110,11 +110,14 @@ public class Spreadsheet.UI.MainWindow : ApplicationWindow {
         show_all ();
     }
 
-    public MainWindow.with_state (Gtk.Application app, int x, int y, int w, int h) {
+    public MainWindow.with_state (Gtk.Application app, int x, int y, int w, int h, bool m) {
         Object (application: app);
         move (x, y);
         default_width = w;
         default_height = h;
+        if (m) {
+            maximize ();
+        }
         try {
             icon = new Pixbuf.from_resource_at_scale ("/xyz/gelez/spreadsheet/icons/icon.svg", 48, 48, true);
         } catch (Error err) {
@@ -130,15 +133,18 @@ public class Spreadsheet.UI.MainWindow : ApplicationWindow {
         show_all ();
     }
 
-    // Save window state
+    // Save position, size and state of window when they're changed
     public override bool configure_event (Gdk.EventConfigure event) {
         int x, y, w, h;
+        bool m;
         get_position (out x, out y);
         get_size (out w, out h);
+        m = this.is_maximized;
         Spreadsheet.App.settings.set_int ("window-x", x);
         Spreadsheet.App.settings.set_int ("window-y", y);
         Spreadsheet.App.settings.set_int ("window-width", w);
         Spreadsheet.App.settings.set_int ("window-height", h);
+        Spreadsheet.App.settings.set_boolean ("window-maximized", m);
 
         return base.configure_event (event);
     }

--- a/src/UI/MainWindow.vala
+++ b/src/UI/MainWindow.vala
@@ -93,22 +93,10 @@ public class Spreadsheet.UI.MainWindow : ApplicationWindow {
     // First time running
     public MainWindow (Gtk.Application app, int w, int h) {
         Object (application: app);
+        window_position = WindowPosition.CENTER;
         default_width = w;
         default_height = h;
-        window_position = WindowPosition.CENTER;
-        try {
-            icon = new Pixbuf.from_resource_at_scale ("/xyz/gelez/spreadsheet/icons/icon.svg", 48, 48, true);
-        } catch (Error err) {
-            debug ("Error: " + err.message);
-        }
-
-        app_stack.add_named (welcome (), "welcome");
-        app_stack.add_named (sheet (), "app");
-        set_titlebar (header);
-
-        add (app_stack);
-        show_welcome ();
-        show_all ();
+        init ();
     }
 
     public MainWindow.with_state (Gtk.Application app, int x, int y, int w, int h, bool m) {
@@ -116,9 +104,13 @@ public class Spreadsheet.UI.MainWindow : ApplicationWindow {
         move (x, y);
         default_width = w;
         default_height = h;
+        init ();
         if (m) {
             maximize ();
         }
+    }
+
+    private void init () {
         try {
             icon = new Pixbuf.from_resource_at_scale ("/xyz/gelez/spreadsheet/icons/icon.svg", 48, 48, true);
         } catch (Error err) {

--- a/src/UI/MainWindow.vala
+++ b/src/UI/MainWindow.vala
@@ -99,6 +99,7 @@ public class Spreadsheet.UI.MainWindow : ApplicationWindow {
         init ();
     }
 
+    // Not a first time running
     public MainWindow.with_state (Gtk.Application app, int x, int y, int w, int h, bool m) {
         Object (application: app);
         move (x, y);

--- a/src/UI/MainWindow.vala
+++ b/src/UI/MainWindow.vala
@@ -90,6 +90,7 @@ public class Spreadsheet.UI.MainWindow : ApplicationWindow {
         redo_button.sensitive = HistoryManager.instance.can_redo ();
     }
 
+    // First time running
     public MainWindow (Gtk.Application app, int w, int h) {
         Object (application: app);
         default_width = w;

--- a/src/UI/MainWindow.vala
+++ b/src/UI/MainWindow.vala
@@ -90,9 +90,10 @@ public class Spreadsheet.UI.MainWindow : ApplicationWindow {
         redo_button.sensitive = HistoryManager.instance.can_redo ();
     }
 
-    public MainWindow (Gtk.Application app) {
+    public MainWindow (Gtk.Application app, int w, int h) {
         Object (application: app);
-        set_default_size (1500, 1000);
+        default_width = w;
+        default_height = h;
         window_position = WindowPosition.CENTER;
         try {
             icon = new Pixbuf.from_resource_at_scale ("/xyz/gelez/spreadsheet/icons/icon.svg", 48, 48, true);
@@ -107,6 +108,39 @@ public class Spreadsheet.UI.MainWindow : ApplicationWindow {
         add (app_stack);
         show_welcome ();
         show_all ();
+    }
+
+    public MainWindow.with_state (Gtk.Application app, int x, int y, int w, int h) {
+        Object (application: app);
+        move (x, y);
+        default_width = w;
+        default_height = h;
+        try {
+            icon = new Pixbuf.from_resource_at_scale ("/xyz/gelez/spreadsheet/icons/icon.svg", 48, 48, true);
+        } catch (Error err) {
+            debug ("Error: " + err.message);
+        }
+
+        app_stack.add_named (welcome (), "welcome");
+        app_stack.add_named (sheet (), "app");
+        set_titlebar (header);
+
+        add (app_stack);
+        show_welcome ();
+        show_all ();
+    }
+
+    // Save window state
+    public override bool configure_event (Gdk.EventConfigure event) {
+        int x, y, w, h;
+        get_position (out x, out y);
+        get_size (out w, out h);
+        Spreadsheet.App.settings.set_int ("window-x", x);
+        Spreadsheet.App.settings.set_int ("window-y", y);
+        Spreadsheet.App.settings.set_int ("window-width", w);
+        Spreadsheet.App.settings.set_int ("window-height", h);
+
+        return base.configure_event (event);
     }
 
     private Welcome welcome () {


### PR DESCRIPTION
![peek 2018-09-19 19-43](https://user-images.githubusercontent.com/26003928/45748746-9184d600-bc44-11e8-87be-a5b143bbf87f.gif)

Fixes #42 

This PR allows the app to save window width, height, x position, y position, and state (whether window is maximized) and restore them when we run the app again.

## Changes Summary

* Add a schema to save window width, height, x position, y position, and state
* Add `meson/post_install.py` to load the schema after installation
* Divide MainWindow method whether the app is first run or not
