### PR TITLE
Improve the looks of style_toggle

### DIFF
--- a/src/UI/MainWindow.vala
+++ b/src/UI/MainWindow.vala
@@ -244,18 +244,19 @@ public class Spreadsheet.UI.MainWindow : ApplicationWindow {
         style_toggle.tooltip_text = "Set colors to letters in a selected cell";
         bool resized = false;
         style_toggle.draw.connect ((cr) => { // draw the color rectangle on the right of the style button
-            int spacing = 20;
+            int spacing = 10;
             int border = get_style_context ().get_border (StateFlags.NORMAL).left;
             int square_size = style_toggle.get_allocated_height () - (border * 2);
             int width = style_toggle.get_allocated_width ();
 
             if (!resized) {
+                style_toggle.get_child ().halign = Gtk.Align.START;
                 style_toggle.width_request += width + spacing + square_size + border; // some space for the color icon
                 resized = true;
             }
 
             cr.set_source_rgb (0, 0, 0);
-            draw_rounded_path (cr, width - (border + square_size), border, square_size, square_size, 2);
+            draw_rounded_path (cr, width - (border + square_size - 5), border + 5, square_size - 10, square_size - 10, 2);
             cr.fill ();
             return false;
         });

--- a/src/UI/MainWindow.vala
+++ b/src/UI/MainWindow.vala
@@ -245,6 +245,7 @@ public class Spreadsheet.UI.MainWindow : ApplicationWindow {
         bool resized = false;
         style_toggle.draw.connect ((cr) => { // draw the color rectangle on the right of the style button
             int spacing = 10;
+            int padding = 5;
             int border = get_style_context ().get_border (StateFlags.NORMAL).left;
             int square_size = style_toggle.get_allocated_height () - (border * 2);
             int width = style_toggle.get_allocated_width ();
@@ -256,7 +257,7 @@ public class Spreadsheet.UI.MainWindow : ApplicationWindow {
             }
 
             cr.set_source_rgb (0, 0, 0);
-            draw_rounded_path (cr, width - (border + square_size - 5), border + 5, square_size - 10, square_size - 10, 2);
+            draw_rounded_path (cr, width - (border + square_size - padding), border + padding, square_size - (padding * 2), square_size - (padding * 2), 2);
             cr.fill ();
             return false;
         });


### PR DESCRIPTION
## BEFORE

![Screenshot from 2019-05-04 13-20-00](https://user-images.githubusercontent.com/26003928/57173757-ab8bc580-6e6f-11e9-9521-1f9766b010fe.png)

## AFTER

![Screenshot from 2019-05-04 13-17-44](https://user-images.githubusercontent.com/26003928/57173756-aaf32f00-6e6f-11e9-944b-0dc0d910635b.png)

## Mockup (as a reference)

![mockup](https://user-images.githubusercontent.com/26003928/57173758-ab8bc580-6e6f-11e9-80d9-f3c4f5a1a2c5.png)

## Changes Summary

* Adjust the spacing between the label of style_toggle and the black square
* Set the alignment of the label of style_toggle to left
* Set margin for the back square
