### PR TITLE
Center letters and numbers in the Sheet widget

### DIFF
--- a/src/Widgets/Sheet.vala
+++ b/src/Widgets/Sheet.vala
@@ -185,8 +185,8 @@ public class Spreadsheet.Widgets.Sheet : EventBox {
 
             TextExtents extents;
             cr.text_extents (i.to_string (), out extents);
-            double x = left_margin - (PADDING + BORDER + extents.width);
-            double y = HEIGHT + HEIGHT * i - (PADDING + BORDER);
+            double x = left_margin / 2 - (BORDER + extents.width / 2);
+            double y = HEIGHT * (i + 1) - (BORDER + extents.height / 2);
 
             cr.move_to (x, y);
             if (i != 0) {
@@ -210,8 +210,11 @@ public class Spreadsheet.Widgets.Sheet : EventBox {
                 set_color (cr, normal);
             }
 
-            double x = left_margin + (WIDTH * i) + PADDING;
-            double y = HEIGHT - PADDING;
+            TextExtents extents;
+            cr.text_extents (letter, out extents);
+            double x = left_margin + (WIDTH * i) + WIDTH / 2 - extents.width / 2;
+            double y = HEIGHT / 2 + extents.height / 2;
+            cr.fill ();
             cr.move_to (x, y);
             cr.show_text (letter);
 

--- a/src/Widgets/Sheet.vala
+++ b/src/Widgets/Sheet.vala
@@ -185,8 +185,8 @@ public class Spreadsheet.Widgets.Sheet : EventBox {
 
             TextExtents extents;
             cr.text_extents (i.to_string (), out extents);
-            double x = left_margin / 2 - (BORDER + extents.width / 2);
-            double y = HEIGHT * (i + 1) - (BORDER + extents.height / 2);
+            double x = left_margin / 2 - extents.width / 2;
+            double y = BORDER + HEIGHT * i + HEIGHT / 2 + extents.height / 2;
 
             cr.move_to (x, y);
             if (i != 0) {
@@ -212,8 +212,8 @@ public class Spreadsheet.Widgets.Sheet : EventBox {
 
             TextExtents extents;
             cr.text_extents (letter, out extents);
-            double x = left_margin + (WIDTH * i) + WIDTH / 2 - extents.width / 2;
-            double y = HEIGHT / 2 + extents.height / 2;
+            double x = left_margin + BORDER + WIDTH * i + WIDTH / 2 - extents.width / 2;
+            double y = BORDER + HEIGHT / 2 + extents.height / 2;
             cr.fill ();
             cr.move_to (x, y);
             cr.show_text (letter);


### PR DESCRIPTION
Fixes #6
(I'm not good at math, so there might be some mistakes…)

## BEFORE

![Screenshot from 2019-05-04 20-59-24](https://user-images.githubusercontent.com/26003928/57178795-10b3db00-6eb1-11e9-8ec5-1954e9339290.png)

## AFTER

![Screenshot from 2019-05-04 22-14-01](https://user-images.githubusercontent.com/26003928/57179542-f92d2000-6eb9-11e9-8c5e-16daa8864d91.png)

## Changes Summary

Sorry for my messy handwriting and figures :disappointed_relieved:

### Description of Variables

![Screenshot from 2019-05-04 22-29-30](https://user-images.githubusercontent.com/26003928/57179764-309ccc00-6ebc-11e9-8c44-beeb70275200.png)

* `left_margin` is the width of the leftmost cells in which has row numbers
* `WIDTH` is the width of the cells excluding the leftmost one
* `HEIGHT` is the height of all cells
* `BORDER` is the thickness of the stroke of cells

### 1. Center numbers on the left of the Sheet widget

#### X Position

![Screenshot from 2019-05-04 22-19-55 (copy)](https://user-images.githubusercontent.com/26003928/57179664-19111380-6ebb-11e9-97ae-5f592b52f2c6.png)

```
x = left_margin / 2 - extents.width / 2;
```

#### Y Position

![Screenshot from 2019-05-04 22-19-55](https://user-images.githubusercontent.com/26003928/57179663-19111380-6ebb-11e9-84a1-96aa34b3214d.png)

```
y = BORDER + HEIGHT * i + HEIGHT / 2 + extents.height / 2;
```

### 2. Center letters on the top of the Sheet widget

#### X Position

![Screenshot from 2019-05-04 22-19-23 (copy)](https://user-images.githubusercontent.com/26003928/57179662-18787d00-6ebb-11e9-9949-718da9ed0848.png)

```
x = left_margin + BORDER + WIDTH * i + WIDTH / 2 - extents.width / 2;
```

#### Y Position

![Screenshot from 2019-05-04 22-19-23](https://user-images.githubusercontent.com/26003928/57179661-18787d00-6ebb-11e9-8668-d388826fae24.png)

```
y = BORDER + HEIGHT / 2 + extents.height / 2;
```
