### PR TITLE
Don't use plural for cell/font settings label

### DIFF
--- a/src/Widgets/StyleModal.vala
+++ b/src/Widgets/StyleModal.vala
@@ -9,8 +9,8 @@ public class Spreadsheet.StyleModal : Gtk.Grid {
 
     public StyleModal (FontStyle font_style, CellStyle cell_style) {
         var style_stack = new Gtk.Stack ();
-        style_stack.add_titled (fonts_grid (font_style), "fonts-grid", _("Fonts"));
-        style_stack.add_titled (cells_grid (cell_style), "cells-grid", _("Cells"));
+        style_stack.add_titled (fonts_grid (font_style), "fonts-grid", _("Font"));
+        style_stack.add_titled (cells_grid (cell_style), "cells-grid", _("Cell"));
 
         var style_stacksw = new Gtk.StackSwitcher ();
         style_stacksw.homogeneous = true;


### PR DESCRIPTION
![Screenshot from 2019-06-26 19-38-50](https://user-images.githubusercontent.com/26003928/60174015-0e378700-984b-11e9-8b12-ea4e10fc9246.png)

As requested at https://github.com/ryonakano/Spreadsheet/pull/64#discussion_r296662739:

> In the context of the app the "Fonts" and the "Cells" attribute are applied on one specific cell si there is no reason to use plural form.
