### PR TITLE
Use commonly used word 'sheet' instead of 'page'

### DIFF
--- a/src/UI/MainWindow.vala
+++ b/src/UI/MainWindow.vala
@@ -309,7 +309,7 @@ public class Spreadsheet.UI.MainWindow : ApplicationWindow {
             title = file_name,
             file_path = path.get_path ()
         };
-        file.add_page (new Page.empty () { title = _("Page 1") });
+        file.add_page (new Page.empty () { title = _("Sheet 1") });
         this.file = file;
         show_all ();
         save_sheet ();


### PR DESCRIPTION
![Screenshot from 2019-06-27 19-04-00](https://user-images.githubusercontent.com/26003928/60257436-68e5e700-990e-11e9-8d27-3e9ebad165d8.png)

As requested at https://github.com/ryonakano/Spreadsheet/pull/64#discussion_r296661383:

> As far as I know the spreadsheet softwares uses "sheet" as a page.

---

At first I hesitated to make this change because I felt naming a new instance of `Page` object as "Sheet" may not make sense, but I found we do essentially the same thing in the following code and there we name a new instance of `Page` object as "Sheet", so I decided to make this PR.

https://github.com/ryonakano/Spreadsheet/blob/3f5f64faff2322bf1a6d940f02908bbc80dc7cfe/src/Services/CSV/CSVParser.vala#L24-L32
