### PR TITLE
Fix typos in the function descriptions

### DIFF
--- a/src/App.vala
+++ b/src/App.vala
@@ -39,7 +39,7 @@ public class Spreadsheet.App : Gtk.Application {
         functions.add (new Function ("tan", Functions.tan, _("Gives the tangent of a number (in radians)")));
         functions.add (new Function ("arccos", Functions.arccos, _("Gives the arc cosine of a number")));
         functions.add (new Function ("arcsin", Functions.arcsin, _("Gives the arc sine of a number")));
-        functions.add (new Function ("arctan", Functions.arctan, _("Gives the arg tangent of a number")));
+        functions.add (new Function ("arctan", Functions.arctan, _("Gives the arc tangent of a number")));
     }
 
     public override void activate () {

--- a/src/App.vala
+++ b/src/App.vala
@@ -23,7 +23,7 @@ public class Spreadsheet.App : Gtk.Application {
         functions.add (new Function ("sum", Functions.sum, _("Add numbers")));
         functions.add (new Function ("mul", Functions.mul, _("Multiply numbers")));
         functions.add (new Function ("div", Functions.div, _("Divide numbers")));
-        functions.add (new Function ("sub", Functions.sub, _("Substract numbers")));
+        functions.add (new Function ("sub", Functions.sub, _("Subtract numbers")));
         functions.add (new Function ("mod", Functions.mod, _("Gives the modulo of numbers")));
 
         functions.add (new Function ("pow", Functions.pow, _("Elevate a number to the power of a second one")));
@@ -34,11 +34,11 @@ public class Spreadsheet.App : Gtk.Application {
         functions.add (new Function ("max", Functions.max, _("Return the biggest value")));
         functions.add (new Function ("mean", Functions.mean, _("Gives the mean of a list of numbers")));
 
-        functions.add (new Function ("cos", Functions.cos, _("Gives the cosinus of a number (in radians)")));
-        functions.add (new Function ("sin", Functions.sin, _("Gives the sinus of an angle (in radians)")));
+        functions.add (new Function ("cos", Functions.cos, _("Gives the cosine of a number (in radians)")));
+        functions.add (new Function ("sin", Functions.sin, _("Gives the sine of an angle (in radians)")));
         functions.add (new Function ("tan", Functions.tan, _("Gives the tangent of a number (in radians)")));
-        functions.add (new Function ("arccos", Functions.arccos, _("Gives the arc cosinus of a number")));
-        functions.add (new Function ("arcsin", Functions.arcsin, _("Gives the arc sinus of a number")));
+        functions.add (new Function ("arccos", Functions.arccos, _("Gives the arc cosine of a number")));
+        functions.add (new Function ("arcsin", Functions.arcsin, _("Gives the arc sine of a number")));
         functions.add (new Function ("arctan", Functions.arctan, _("Gives the arg tangent of a number")));
     }
 


### PR DESCRIPTION
## Changes Summary

* Fix a typo: substruct to subtract
* The words "cosinus", "sinus" seem to be a French

I'm not good at math, so I wonder why "**arg** tangent" is not "**arc** tangent" like other trigonometric functions (arc cosine and arc sine). Should we also fix this?

```vala
functions.add (new Function ("arccos", Functions.arccos, _("Gives the arc cosine of a number")));
functions.add (new Function ("arcsin", Functions.arcsin, _("Gives the arc sine of a number")));
functions.add (new Function ("arctan", Functions.arctan, _("Gives the arg tangent of a number")));
```
