### PR TITLE
Support scrolling sheets

### DIFF
--- a/src/Widgets/Sheet.vala
+++ b/src/Widgets/Sheet.vala
@@ -29,6 +29,7 @@ public class Spreadsheet.Widgets.Sheet : EventBox {
     public Sheet (Page page, MainWindow window) {
         this.page = page;
         this.window = window;
+        set_size_request ((int) get_left_margin () + WIDTH * page.columns, HEIGHT * page.lines);
         foreach (var cell in page.cells) {
             if (selected_cell == null) {
                 selected_cell = cell;


### PR DESCRIPTION
Fixes #73

As commented in https://github.com/ryonakano/Spreadsheet/pull/11#issuecomment-298685540, requesting the widget size seems to allow to scroll, but I got another error message other than the ones in #52 for some reason :man_shrugging:

```
(com.github.ryonakano.spreadsheet:24449): Gtk-CRITICAL **: 12:47:38.257: gtk_box_gadget_distribute: assertion 'size >= 0' failed in GtkScrollbar
r
```
