### PR TITLE
Use convenient Gdk.cairo_set_source_rgba method

### DIFF
--- a/src/Widgets/Sheet.vala
+++ b/src/Widgets/Sheet.vala
@@ -147,22 +147,8 @@ public class Spreadsheet.Widgets.Sheet : EventBox {
         return left_ext.width + BORDER;
     }
 
-    // I hope Vala will support extension methods one day...
-    private void set_color (Context cr, RGBA color) {
-        if (color.blue > 1.0) {
-            color.blue = color.blue / 256;
-        }
-        if (color.red > 1.0) {
-            color.red = color.red / 256;
-        }
-        if (color.green > 1.0) {
-            color.green = color.green / 256;
-        }
-        cr.set_source_rgba (color.red, color.green, color.blue, color.alpha);
-    }
-
     public override bool draw (Context cr) {
-        RGBA default_cell_stroke = { 77.0, 77.0, 77.0, 1 };
+        RGBA default_cell_stroke = { 0.3, 0.3, 0.3, 1 };
         RGBA default_font_color = { 0, 0, 0, 1 };
 
         var style = window.get_style_context ();
@@ -181,7 +167,7 @@ public class Spreadsheet.Widgets.Sheet : EventBox {
         cr.fill ();
 
         // draw the letters and the numbers on the side
-        set_color (cr, normal);
+        Gdk.cairo_set_source_rgba (cr, normal);
         cr.set_line_width (BORDER);
 
         // numbers on the left side
@@ -194,9 +180,9 @@ public class Spreadsheet.Widgets.Sheet : EventBox {
                 style.render_frame (cr, 0, HEIGHT + BORDER + i * HEIGHT, left_margin, HEIGHT);
                 cr.restore ();
 
-                set_color (cr, selected);
+                Gdk.cairo_set_source_rgba (cr, selected);
             } else {
-                set_color (cr, normal);
+                Gdk.cairo_set_source_rgba (cr, normal);
             }
 
             TextExtents extents;
@@ -221,9 +207,9 @@ public class Spreadsheet.Widgets.Sheet : EventBox {
                 style.render_frame (cr, left_margin + BORDER + i * WIDTH, 0, WIDTH, HEIGHT);
                 cr.restore ();
 
-                set_color (cr, selected);
+                Gdk.cairo_set_source_rgba (cr, selected);
             } else {
-                set_color (cr, normal);
+                Gdk.cairo_set_source_rgba (cr, normal);
             }
 
             TextExtents extents;
@@ -243,7 +229,7 @@ public class Spreadsheet.Widgets.Sheet : EventBox {
             Gdk.RGBA bg_default = { 255, 255, 255, 0 };
             if (bg != bg_default) {
                 cr.save ();
-                set_color (cr, bg);
+                Gdk.cairo_set_source_rgba (cr, bg);
                 cr.rectangle (left_margin + BORDER + cell.column * WIDTH, HEIGHT + BORDER + cell.line * HEIGHT, WIDTH, HEIGHT);
                 cr.fill ();
                 cr.restore ();
@@ -261,9 +247,9 @@ public class Spreadsheet.Widgets.Sheet : EventBox {
             }
 
             if (sr != sr_default) {
-                set_color (cr, sr);
+                Gdk.cairo_set_source_rgba (cr, sr);
             } else {
-                set_color (cr, default_cell_stroke);
+                Gdk.cairo_set_source_rgba (cr, default_cell_stroke);
             }
 
             if (cell.selected) {
@@ -279,9 +265,9 @@ public class Spreadsheet.Widgets.Sheet : EventBox {
             Gdk.RGBA color_default = { 0, 0, 0, 1 };
             cr.save ();
             if (color != color_default) {
-                set_color (cr, color);
+                Gdk.cairo_set_source_rgba (cr, color);
             } else {
-                set_color (cr, default_font_color);
+                Gdk.cairo_set_source_rgba (cr, default_font_color);
             }
 
             TextExtents extents;


### PR DESCRIPTION
## Before
![Screenshot from 2020-01-03 11-39-02](https://user-images.githubusercontent.com/26003928/71704439-cf981000-2e1d-11ea-8ea1-13fe009a112a.png)

## After
![Screenshot from 2020-01-03 11-37-47](https://user-images.githubusercontent.com/26003928/71704438-cf981000-2e1d-11ea-8b86-9434dc495f14.png)

There seems to be [a useful method](https://valadoc.org/gdk-3.0/Gdk.cairo_set_source_rgba.html) that would be an alternative to our custom method `set_color`. I believe the color doesn't change between `master` and this branch…
