### PR TITLE
Use the correct values for Gdk.RGBA

### DIFF
--- a/src/Models/CellStyle.vala
+++ b/src/Models/CellStyle.vala
@@ -4,8 +4,8 @@ public class Spreadsheet.CellStyle : Object {
     public double stroke_width { get; construct set; }
 
     public CellStyle () {
-        Gdk.RGBA bg = { 255, 255, 255, 0 };
-        Gdk.RGBA sr = { 0, 0, 0, 0 };
+        Gdk.RGBA bg = { 1, 1, 1, 1 };
+        Gdk.RGBA sr = { 0, 0, 0, 1 };
         double sr_w = 1.0;
         Object (
             background: bg,
@@ -15,10 +15,10 @@ public class Spreadsheet.CellStyle : Object {
     }
 
     public void bg_remove () {
-        background = { 255, 255, 255, 0 };
+        background = { 1, 1, 1, 1 };
     }
 
     public void sr_remove () {
-        stroke = { 0, 0, 0, 0 };
+        stroke = { 0, 0, 0, 1 };
     }
 }

--- a/src/Widgets/Sheet.vala
+++ b/src/Widgets/Sheet.vala
@@ -240,7 +240,7 @@ public class Spreadsheet.Widgets.Sheet : EventBox {
         // draw the cells
         foreach (var cell in page.cells) {
             Gdk.RGBA bg = cell.cell_style.background;
-            Gdk.RGBA bg_default = { 255, 255, 255, 0 };
+            Gdk.RGBA bg_default = { 1, 1, 1, 1 };
             if (bg != bg_default) {
                 cr.save ();
                 set_color (cr, bg);
@@ -250,7 +250,7 @@ public class Spreadsheet.Widgets.Sheet : EventBox {
             }
 
             Gdk.RGBA sr = cell.cell_style.stroke;
-            Gdk.RGBA sr_default = { 0, 0, 0, 0 };
+            Gdk.RGBA sr_default = { 0, 0, 0, 1 };
             double sr_w = cell.cell_style.stroke_width;
             cr.save ();
 

--- a/src/Widgets/StyleModal.vala
+++ b/src/Widgets/StyleModal.vala
@@ -138,8 +138,8 @@ public class Spreadsheet.StyleModal : Gtk.Grid {
 
         // Set the sensitivities of the br_remove_button, sr_reset_button and sr_width_spin by whether they have already reset background/stroke colors to the default ones or not when…
         // 1. widgets are created
-        Gdk.RGBA bg_default_color = { 255, 255, 255, 0 };
-        Gdk.RGBA sr_default_color = { 0, 0, 0, 0 };
+        Gdk.RGBA bg_default_color = { 1, 1, 1, 1 };
+        Gdk.RGBA sr_default_color = { 0, 0, 0, 1 };
         bg_reset_button.sensitive = check_color (bg_button, bg_default_color);
         sr_reset_button.sensitive = check_color (sr_button, sr_default_color);
         sr_width_spin.sensitive = check_color (sr_button, sr_default_color);


### PR DESCRIPTION
According to [GDK 3 Reference Manual for Gdk.RGBA](https://developer.gnome.org/gdk3/stable/gdk3-RGBA-Colors.html):

> All values are in the range from 0.0 to 1.0 inclusive. So the color (0.0, 0.0, 0.0, 0.0) represents transparent black and (1.0, 1.0, 1.0, 1.0) is opaque white.

So `{255, 255, 255, 1}` seems to be an invalid value, although it renders as white.

Also, make sure to specify `1` for alpha values to render the default stroke and fill colors correctly:

## Before
![Screenshot from 2020-01-03 11-51-35](https://user-images.githubusercontent.com/26003928/71704765-a7111580-2e1f-11ea-89d5-13752c24d1c0.png)

## After
![Screenshot from 2020-01-03 11-50-07](https://user-images.githubusercontent.com/26003928/71704769-aa0c0600-2e1f-11ea-91a5-e712729f8364.png)
